### PR TITLE
fix path

### DIFF
--- a/jQuery-URL-Parser-Rails.gemspec
+++ b/jQuery-URL-Parser-Rails.gemspec
@@ -1,9 +1,8 @@
 # coding: utf-8
-require File.expand_path('../lib/JQueryUrlParserRails/version', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name          = "jQuery-URL-Parser-Rails"
-  gem.version       = JQueryUrlParserRails::VERSION
+  gem.version       = '0.0.1'
   gem.authors       = ["Dirk Eisenberg"]
   gem.email         = ["dirk.eisenberg@gmail.com"]
   gem.description   = %q{Simple way to integrate the url parameters jquery plugin in the asset pipeline of rails}

--- a/lib/jQuery-URL-Parser-Rails.rb
+++ b/lib/jQuery-URL-Parser-Rails.rb
@@ -2,5 +2,5 @@
 require 'rails'
 
 # it's an engine
-require 'JQueryUrlParserRails/engine'
-require 'JQueryUrlParserRails/version'
+require 'jQueryUrlParserRails/engine'
+require 'jQueryUrlParserRails/version'

--- a/lib/jQuery-URL-Parser-Rails.rb
+++ b/lib/jQuery-URL-Parser-Rails.rb
@@ -2,5 +2,5 @@
 require 'rails'
 
 # it's an engine
-require 'jQueryUrlParserRails/engine'
-require 'jQueryUrlParserRails/version'
+require 'jQueryURLParserRails/engine'
+require 'jQueryURLParserRails/version'

--- a/lib/jQueryURLParserRails/engine.rb
+++ b/lib/jQueryURLParserRails/engine.rb
@@ -1,4 +1,4 @@
-require "jQueryUrlParserRails/version"
+require "jQueryURLParserRails/version"
 
 module JQueryUrlParserRails
   class Engine < ::Rails::Engine

--- a/lib/jQueryURLParserRails/engine.rb
+++ b/lib/jQueryURLParserRails/engine.rb
@@ -1,4 +1,4 @@
-require "JQueryUrlParserRails/version"
+require "jQueryUrlParserRails/version"
 
 module JQueryUrlParserRails
   class Engine < ::Rails::Engine


### PR DESCRIPTION
I tried to install this gem in ruby 2.1, and Gemfile is,
```
gem 'jQuery-URL-Parser-Rails', git: 'https://github.com/dei79/jQuery-URL-Parser-Rails.git'
```
but it was refused.
```
Fetching https://github.com/dei79/jQuery-URL-Parser-Rails.git
There was a LoadError while loading jQuery-URL-Parser-Rails.gemspec: 
cannot load such file --
/root/apps/vendor/bundle/ruby/2.1.0/bundler/gems/jQuery-URL-Parser-Rails-4809e0d11232/lib/JQueryUrlParserRails/version
from
/root/apps/vendor/bundle/ruby/2.1.0/bundler/gems/jQuery-URL-Parser-Rails-4809e0d11232/jQuery-URL-Parser-Rails.gemspec:2:in
`<main>'

Does it try to require a relative path? That's been removed in Ruby 1.9.
```

And, an error occured when i tried to 'bundle exec rake assets:precompile RAILS_ENV=production',
```
rake aborted!
LoadError: cannot load such file -- JQueryUrlParserRails/engine
```

so, i fixed for the time being.
sorry for my rough fix.